### PR TITLE
Return decorrlation length for requested trench direction only

### DIFF
--- a/R/estimateTrenchDecorrelation.R
+++ b/R/estimateTrenchDecorrelation.R
@@ -322,20 +322,34 @@ calcNonEquidistantAC1 <- function(x, pos, direction, lag = c(0, 1)) {
 #'
 #' @export
 #'
-estimateTrenchDecorrelation <- function(data, .var = "d18O", vscale = "depth") {
+estimateTrenchDecorrelation <- function(data,
+                                        direction = c("horizontal", "vertical"),
+                                        .var = "d18O", vscale = "depth") {
 
   is.trench(data, check = "incl.pos")
 
+  direction <- tryCatch(
+    {
+      direction <- match.arg(direction, c("horizontal", "vertical"))
+      c(horizontal = 1, vertical = 2)[[direction]]
+    },
+    error = function(cond) {
+      stop("'direction' must be one of 'horizontal' or 'vertical'.",
+           call. = FALSE)
+    }
+  )
+
   # check for equidistance
-  has.horizontal.equidistance <- is.equidistant(pos.h <- getX(data))
-  has.vertical.equidistance   <- is.equidistant(pos.v <- getZ(data,
-                                                              vscale = vscale))
+  has.equidistance <- if (direction == 1)
+                        is.equidistant(pos <- getX(data))
+                      else
+                        is.equidistant(pos <- getZ(data, vscale = vscale))
 
   # trench 2D matrix
   x <- make2D(data, .var = .var, simplify = TRUE)
 
   # remove trench surface region if needed
-  if (has.horizontal.equidistance | has.vertical.equidistance) {
+  if (has.equidistance) {
 
     x.no.surface <- data %>%
       removeSurfaceRegion(.var = .var, vscale = vscale) %>%
@@ -343,33 +357,26 @@ estimateTrenchDecorrelation <- function(data, .var = "d18O", vscale = "depth") {
   }
 
   # get autocorrelation values
-  a1.h <- if (has.horizontal.equidistance) {
-            calcEquidistantAC1(x, x.no.surface, direction = 1)
-          } else {
-            calcNonEquidistantAC1(x, pos = pos.h, direction = 1)
-          }
 
-  a1.v <- if (has.vertical.equidistance) {
-            calcEquidistantAC1(x, x.no.surface, direction = 2)
-          } else {
-            calcNonEquidistantAC1(x, pos = pos.v, direction = 2)
-          }
+  a1 <- if (has.equidistance) {
+          calcEquidistantAC1(x, x.no.surface, direction)
+        } else {
+          calcNonEquidistantAC1(x, pos = pos, direction)
+        }
 
-  if (a1.h <= 0) a1.h <- NA
-  if (a1.v <= 0) a1.v <- NA
-
-  if (is.na(a1.h) | is.na(a1.v)) {
+  if (a1 <= 0) {
     warning("NA decorrelation length due to negative ",
             "lag-1 autocorrelation estimate.", call. = FALSE)
+    a1 <- NA
   }
 
   # sampling resolutions depending on autocorrelation estimation method
-  dx <- if (has.horizontal.equidistance) pos.h[2] - pos.h[1] else 1
-  dz <- if (has.vertical.equidistance) pos.v[2] - pos.v[1] else 1
+  res <- if (has.equidistance) pos[2] - pos[1] else 1
 
   # estimated decorrelation length assuming AR1 process
-  lambda <- -1 * c(dx, dz) / log(c(a1.h, a1.v))
+  lambda <- -1 * res / log(a1)
 
-  tibble::tibble(direction = c("horizontal", "vertical"), lambda = lambda)
+  # return
+  if (direction == 1) c(horizontal = lambda) else c(vertical = lambda)
 
 }

--- a/R/estimateTrenchDecorrelation.R
+++ b/R/estimateTrenchDecorrelation.R
@@ -261,10 +261,10 @@ calcNonEquidistantAC1 <- function(x, pos, direction, lag = c(0, 1)) {
 
 }
 
-#' Horizontal and vertical decorrelation length of trench dataset
+#' Horizontal or vertical decorrelation length of trench dataset
 #'
-#' Calculate the decorrelation length in horizontal and vertical direction of a
-#' trench dataset. For this, the lag-1 autocorrelation across each vertical and
+#' Calculate the decorrelation length in horizontal or vertical direction of a
+#' trench dataset. For this, the lag-1 autocorrelation across each vertical or
 #' horizontal trench sampling position is estimated, averaged, and the
 #' decorrelation length ("lambda") is calculated assuming an AR1 autoregressive
 #' process:\cr
@@ -279,38 +279,41 @@ calcNonEquidistantAC1 <- function(x, pos, direction, lag = c(0, 1)) {
 #'
 #' In the equidistant case, the method uses the base R \code{\link[stats]{acf}}
 #' function, which ignores leading or trailing NA values but cannot handle
-#' internal NAs. For that reason, any rows or columns of the trench dataset (as
-#' viewed in 2D matrix form) that contain internal NA values trigger a warning
-#' and are removed from the data before estimation.
+#' internal NAs. For that reason, any rows, or columns, of the trench dataset
+#' (as viewed in 2D matrix form) that contain internal NA values trigger a
+#' warning (see examples) and are removed from the data before estimation.
 #'
 #' For non-equidistantly sampled data, the method utilizes the Gaussian kernel
 #' estimation technique of Rehfeld et al. (2011) to account for the irregular
 #' sampling. Here, NA values are generally allowed, but if more than 1/3 of the
-#' data points in a row or column are NA, the corresponding autocorrelation is
-#' set to NA with a warning. These NA values from problematic rows or columns do
-#' not influence the decorrelation length, since any NA values are removed from
-#' the individual autocorrelation estimates upon averaging, albeit the entire
-#' trench dataset contains too many NAs.
+#' data points in a row, or column, are NA, the corresponding autocorrelation is
+#' set to NA with a warning (see examples). These NA values from problematic
+#' rows or columns do not influence the decorrelation length, since any NA
+#' values are removed from the individual autocorrelation estimates upon
+#' averaging, unless the entire trench dataset contains too many NAs.
 #'
+#' @param direction character string signalling for which trench direction to
+#'   compute the decorrelation length: "horizontal" (default) or "vertical".
 #' @param .var character string with the name of the trench variable for which to
-#'   compute the decorrelation lengths; see also \code{\link{make2D}}.
+#'   compute the decorrelation length; see also \code{\link{make2D}}.
 #' @inheritParams getZ
 #'
-#' @return a tibble of two variables: the \code{direction} of the decorrelation
-#'   length calculation as a character string ("horizontal" and "vertical"), and
-#'   the corresponding estimated decorrelation lengths ("\code{lambda}"),
-#'   measured in the same units as the respective sampling position.
+#' @return a named length-1 vector with the estimated decorrelation length in
+#'   the requested direction, measured in the same units as the respective
+#'   sampling position.
 #'
 #' @author Thomas Münch
 #' @examples
 #'
 #' # data sampled irregulary in horizontal, regularly in vertical direction
 #' estimateTrenchDecorrelation(t13.trench1)
+#' estimateTrenchDecorrelation(t13.trench1, direction = "vertical")
 #'   # <- the warnings originate from removing trench rows and columns which
 #'   # contain any NA, or too many NA values, depending on estimation method
 #'
 #' # data sampled regularly in both directions
-#' estimateTrenchDecorrelation(t15.trench2)
+#' estimateTrenchDecorrelation(t15.trench2, "horizontal")
+#' estimateTrenchDecorrelation(t15.trench2, "vertical")
 #' estimateTrenchDecorrelation(t15.trench2, .var = "dxs")
 #'
 #' @seealso \code{\link[stats]{acf}}, \code{\link{make2D}}

--- a/man/estimateTrenchDecorrelation.Rd
+++ b/man/estimateTrenchDecorrelation.Rd
@@ -2,29 +2,36 @@
 % Please edit documentation in R/estimateTrenchDecorrelation.R
 \name{estimateTrenchDecorrelation}
 \alias{estimateTrenchDecorrelation}
-\title{Horizontal and vertical decorrelation length of trench dataset}
+\title{Horizontal or vertical decorrelation length of trench dataset}
 \usage{
-estimateTrenchDecorrelation(data, .var = "d18O", vscale = "depth")
+estimateTrenchDecorrelation(
+  data,
+  direction = c("horizontal", "vertical"),
+  .var = "d18O",
+  vscale = "depth"
+)
 }
 \arguments{
 \item{data}{a trench data set following the default structure used in the
 package.}
 
+\item{direction}{character string signalling for which trench direction to
+compute the decorrelation length: "horizontal" (default) or "vertical".}
+
 \item{.var}{character string with the name of the trench variable for which to
-compute the decorrelation lengths; see also \code{\link{make2D}}.}
+compute the decorrelation length; see also \code{\link{make2D}}.}
 
 \item{vscale}{the name of the vertical scale as a character string; defaults
 to \code{"depth"}.}
 }
 \value{
-a tibble of two variables: the \code{direction} of the decorrelation
-  length calculation as a character string ("horizontal" and "vertical"), and
-  the corresponding estimated decorrelation lengths ("\code{lambda}"),
-  measured in the same units as the respective sampling position.
+a named length-1 vector with the estimated decorrelation length in
+  the requested direction, measured in the same units as the respective
+  sampling position.
 }
 \description{
-Calculate the decorrelation length in horizontal and vertical direction of a
-trench dataset. For this, the lag-1 autocorrelation across each vertical and
+Calculate the decorrelation length in horizontal or vertical direction of a
+trench dataset. For this, the lag-1 autocorrelation across each vertical or
 horizontal trench sampling position is estimated, averaged, and the
 decorrelation length ("lambda") is calculated assuming an AR1 autoregressive
 process:\cr
@@ -40,28 +47,30 @@ and non-equidistantly sampled data.
 
 In the equidistant case, the method uses the base R \code{\link[stats]{acf}}
 function, which ignores leading or trailing NA values but cannot handle
-internal NAs. For that reason, any rows or columns of the trench dataset (as
-viewed in 2D matrix form) that contain internal NA values trigger a warning
-and are removed from the data before estimation.
+internal NAs. For that reason, any rows, or columns, of the trench dataset
+(as viewed in 2D matrix form) that contain internal NA values trigger a
+warning (see examples) and are removed from the data before estimation.
 
 For non-equidistantly sampled data, the method utilizes the Gaussian kernel
 estimation technique of Rehfeld et al. (2011) to account for the irregular
 sampling. Here, NA values are generally allowed, but if more than 1/3 of the
-data points in a row or column are NA, the corresponding autocorrelation is
-set to NA with a warning. These NA values from problematic rows or columns do
-not influence the decorrelation length, since any NA values are removed from
-the individual autocorrelation estimates upon averaging, albeit the entire
-trench dataset contains too many NAs.
+data points in a row, or column, are NA, the corresponding autocorrelation is
+set to NA with a warning (see examples). These NA values from problematic
+rows or columns do not influence the decorrelation length, since any NA
+values are removed from the individual autocorrelation estimates upon
+averaging, unless the entire trench dataset contains too many NAs.
 }
 \examples{
 
 # data sampled irregulary in horizontal, regularly in vertical direction
 estimateTrenchDecorrelation(t13.trench1)
+estimateTrenchDecorrelation(t13.trench1, direction = "vertical")
   # <- the warnings originate from removing trench rows and columns which
   # contain any NA, or too many NA values, depending on estimation method
 
 # data sampled regularly in both directions
-estimateTrenchDecorrelation(t15.trench2)
+estimateTrenchDecorrelation(t15.trench2, "horizontal")
+estimateTrenchDecorrelation(t15.trench2, "vertical")
 estimateTrenchDecorrelation(t15.trench2, .var = "dxs")
 
 }

--- a/tests/testthat/test-estimateTrenchDecorrelation.R
+++ b/tests/testthat/test-estimateTrenchDecorrelation.R
@@ -326,6 +326,10 @@ test_that("lag-1 autocorrelation estimation works", {
 
 test_that("decorrelation length estimation works", {
 
+  expect_error(estimateTrenchDecorrelation(t13.trench1, direction = "foo"),
+               "'direction' must be one of 'horizontal' or 'vertical'.",
+               fixed = TRUE)
+
   # case I: equidistant in vertical, non-equidistant in horizontal diretion
 
   x <- t13.trench1 %>% make2D(simplify = TRUE)
@@ -337,16 +341,17 @@ test_that("decorrelation length estimation works", {
     a1.v <- calcEquidistantAC1(x, x.no.surface, direction = 2)
     })
 
-  expected <- tibble::tibble(
-    direction = c("horizontal", "vertical"),
-    lambda = c(-1 / log(a1.h), -3 / log(a1.v))
-  )
+  expected1 <- c(horizontal = -1 / log(a1.h))
+  expected2 <- c(vertical = -3 / log(a1.v))
 
-  actual <- suppressWarnings(estimateTrenchDecorrelation(t13.trench1))
+  actual1 <- suppressWarnings(estimateTrenchDecorrelation(t13.trench1))
+  actual2 <- suppressWarnings(
+    estimateTrenchDecorrelation(t13.trench1, direction = "vertical"))
 
-  expect_equal(actual, expected)
+  expect_equal(actual1, expected1)
+  expect_equal(actual2, expected2)
 
-  # case I: non-equidistant in vertical, equidistant in horizontal diretion
+  # case II: non-equidistant in vertical, equidistant in horizontal diretion
 
   # remove rows to get non-equidistant vertical sampling
   n <- sort(sample(1 : length(getZ(t15.trench2)), size = 70))
@@ -359,14 +364,14 @@ test_that("decorrelation length estimation works", {
   a1.h <- calcEquidistantAC1(x, x.no.surface, direction = 1)
   a1.v <- calcNonEquidistantAC1(x, pos = getZ(trench), direction = 2)
 
-  expected <- tibble::tibble(
-    direction = c("horizontal", "vertical"),
-    lambda = c(-5 / log(a1.h), -1 / log(a1.v))
-  )
+  expected1 <- c(horizontal = -5 / log(a1.h))
+  expected2 <- c(vertical = -1 / log(a1.v))
 
-  actual <- estimateTrenchDecorrelation(trench)
+  actual1 <- estimateTrenchDecorrelation(trench)
+  actual2 <- estimateTrenchDecorrelation(trench, direction = "vertical")
 
-  expect_equal(actual, expected)
+  expect_equal(actual1, expected1)
+  expect_equal(actual2, expected2)
 
 })
 
@@ -380,8 +385,7 @@ test_that("in case of estimated a1 < 0 the user gets NA decorrelation", {
   expect_warning(actual <- estimateTrenchDecorrelation(x), m)
 
   # check that lambda is really NA and not NaN
-  expect_true(is.na(as.character(actual$lambda[1])))
-  expect_false(is.na(as.character(actual$lambda[2])))
+  expect_true(is.na(as.character(actual)))
 
   # also check with synthetic data
   n <- 1000
@@ -396,6 +400,6 @@ test_that("in case of estimated a1 < 0 the user gets NA decorrelation", {
                              .id = "profileName")
 
   expect_warning(estimateTrenchDecorrelation(trench, .var = "data"), m)
-  expect_true(is.na(as.character(actual$lambda[1])))
+  expect_true(is.na(as.character(actual)))
 
 })


### PR DESCRIPTION
This changes the output behaviour of the trench decorrelation length estimation in `estimateTrenchDecorrelation()` from returning both direction results per default to calculating and returning only that direction which is requested via a respective new function parameter, as suggested by #14.